### PR TITLE
forgejo: add support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,8 @@ clippy_task:
         - env:
               RUST_FEATURES: "--features gitlab"
         - env:
+              RUST_FEATURES: "--features forgejo"
+        - env:
               RUST_FEATURES: "--all-features"
     container:
         image: rust:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -345,6 +352,7 @@ dependencies = [
  "derive_builder",
  "directories",
  "env_logger",
+ "forgejo-api",
  "gitlab",
  "graphql_client",
  "human-panic",
@@ -480,12 +488,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "forgejo-api"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f855a38f4ebd722f5955cb482cd051fe6499f9cfaab2f3cabf955d4c32c1327d"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "soft_assert",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "url",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -505,10 +549,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "futures-sink"
@@ -528,8 +594,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1122,6 +1190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1595,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -1781,6 +1860,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "soft_assert"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5097ec7ea7218135541ad96348f1441d0c616537dd4ed9c47205920c35d7d97"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2120,6 +2205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,7 +2231,14 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 default = ["github"]
 github = ["graphql_client", "reqwest", "serde_json", "url"]
 gitlab = ["dep:gitlab"]
+forgejo = ["dep:forgejo-api"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
@@ -32,3 +33,6 @@ url = { version = "2.5.4", optional = true }
 
 # gitlab feature
 gitlab = { version = "=0.1808.0", optional = true }
+
+# forgejo feature
+forgejo-api = { version = "0.10", features = ["sync"], optional = true }

--- a/src/account.rs
+++ b/src/account.rs
@@ -19,6 +19,9 @@ mod github;
 #[cfg(feature = "gitlab")]
 mod gitlab;
 
+#[cfg(feature = "forgejo")]
+mod forgejo;
+
 #[derive(Debug, Error)]
 #[error("failed to fetch items")]
 pub enum ItemError {
@@ -44,7 +47,7 @@ pub trait ItemSource {
 
 #[derive(Debug, Error)]
 pub enum AccountError {
-    #[cfg(not(all(feature = "github", feature = "gitlab")))]
+    #[cfg(not(all(feature = "github", feature = "gitlab", feature = "forgejo")))]
     #[error("unsupported service: {}", service)]
     UnsupportedService { service: &'static str },
     #[error("unknown service: {}", service)]
@@ -78,6 +81,20 @@ pub fn connect(account: Account) -> Result<Box<dyn ItemSource>, AccountError> {
         "gitlab" => {
             Err(AccountError::UnsupportedService {
                 service: "gitlab",
+            })
+        },
+
+        #[cfg(feature = "forgejo")]
+        "forgejo" => {
+            Ok(Box::new(forgejo::ForgejoQuery::new(
+                account.hostname,
+                account.secret,
+            )))
+        },
+        #[cfg(not(feature = "forgejo"))]
+        "forgejo" => {
+            Err(AccountError::UnsupportedService {
+                service: "forgejo",
             })
         },
 

--- a/src/account/forgejo.rs
+++ b/src/account/forgejo.rs
@@ -1,0 +1,393 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Forgejo integration using the `forgejo-api` crate (REST API with sync feature).
+
+use chrono::NaiveDate;
+use forgejo_api::structs::{
+    Issue, IssueSearchIssuesQuery, IssueSearchIssuesQueryState, IssueSearchIssuesQueryType,
+    StateType,
+};
+use forgejo_api::sync::Forgejo;
+use forgejo_api::Auth;
+use log::{error, warn};
+use url::Url;
+
+use crate::account::prelude::*;
+use crate::todo::{Due, TodoKind, TodoStatus};
+
+struct ForgejoItem {
+    due: Option<Due>,
+    summary: String,
+    description: String,
+    kind: TodoKind,
+    status: TodoStatus,
+    url: String,
+}
+
+impl ForgejoItem {
+    fn from_issue(issue: Issue, is_pull_request: bool) -> Self {
+        let kind = if is_pull_request {
+            TodoKind::PullRequest
+        } else {
+            TodoKind::Issue
+        };
+
+        let state = issue.state.unwrap_or(StateType::Open);
+        let has_assignees = issue
+            .assignees
+            .as_ref()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false);
+
+        let status = match state {
+            StateType::Closed => {
+                if is_pull_request {
+                    // For PRs, check if it was merged
+                    // The `pull_request` field contains merge info if it's a PR
+                    if issue
+                        .pull_request
+                        .as_ref()
+                        .and_then(|pr| pr.merged)
+                        .unwrap_or(false)
+                    {
+                        TodoStatus::Completed
+                    } else {
+                        TodoStatus::Cancelled
+                    }
+                } else {
+                    TodoStatus::Completed
+                }
+            },
+            StateType::Open => {
+                if has_assignees {
+                    TodoStatus::InProcess
+                } else {
+                    TodoStatus::NeedsAction
+                }
+            },
+        };
+
+        // Extract due date from milestone if present
+        // Convert from time::OffsetDateTime to chrono::NaiveDate
+        let due = issue
+            .milestone
+            .as_ref()
+            .and_then(|m| m.due_on.as_ref())
+            .map(|dt| {
+                let date = dt.date();
+                NaiveDate::from_ymd_opt(date.year(), date.month() as u32, date.day() as u32)
+                    .expect("valid date from API")
+            })
+            .map(Due::Date);
+
+        Self {
+            due,
+            summary: issue.title.unwrap_or_default(),
+            description: issue.body.unwrap_or_default(),
+            kind,
+            status,
+            url: issue.html_url.map(|u| u.to_string()).unwrap_or_default(),
+        }
+    }
+}
+
+pub struct ForgejoQuery {
+    client: Result<Forgejo, forgejo_api::ForgejoError>,
+}
+
+impl ForgejoQuery {
+    pub fn new(host: Option<String>, token: String) -> Self {
+        let host = host.unwrap_or_else(|| "codeberg.org".into());
+        let url = Url::parse(&format!("https://{host}")).unwrap_or_else(|_| {
+            // Fallback if the host is malformed
+            Url::parse("https://codeberg.org").unwrap()
+        });
+
+        let client = Forgejo::new(Auth::Token(&token), url);
+
+        ForgejoQuery {
+            client,
+        }
+    }
+
+    fn query_user(client: &Forgejo, filters: &[Filter]) -> Result<Vec<ForgejoItem>, ItemError> {
+        let mut items = Vec::new();
+
+        // Build label filter string (comma-separated)
+        let labels: Option<String> = {
+            let label_list: Vec<&str> = filters
+                .iter()
+                .map(|f| {
+                    match f {
+                        Filter::Label(l) => l.as_str(),
+                    }
+                })
+                .collect();
+            if label_list.is_empty() {
+                None
+            } else {
+                Some(label_list.join(","))
+            }
+        };
+
+        // Query issues assigned to the API user.
+        {
+            let query = IssueSearchIssuesQuery {
+                assigned: Some(true),
+                state: Some(IssueSearchIssuesQueryState::Open),
+                r#type: Some(IssueSearchIssuesQueryType::Issues),
+                labels: labels.clone(),
+                ..Default::default()
+            };
+
+            let (_, assigned_issues) = client.issue_search_issues(query).send().map_err(|err| {
+                error!("failed to query assigned issues: {err:?}");
+                ItemError::QueryError {
+                    service: "forgejo",
+                    message: format!("failed to query assigned issues: {err}"),
+                }
+            })?;
+
+            items.extend(
+                assigned_issues
+                    .into_iter()
+                    .map(|i| ForgejoItem::from_issue(i, false)),
+            );
+        }
+
+        // Query issues created by the API user.
+        {
+            let query = IssueSearchIssuesQuery {
+                created: Some(true),
+                state: Some(IssueSearchIssuesQueryState::Open),
+                r#type: Some(IssueSearchIssuesQueryType::Issues),
+                labels: labels.clone(),
+                ..Default::default()
+            };
+
+            let (_, created_issues) = client.issue_search_issues(query).send().map_err(|err| {
+                error!("failed to query created issues: {err:?}");
+                ItemError::QueryError {
+                    service: "forgejo",
+                    message: format!("failed to query created issues: {err}"),
+                }
+            })?;
+
+            items.extend(
+                created_issues
+                    .into_iter()
+                    .map(|i| ForgejoItem::from_issue(i, false)),
+            );
+        }
+
+        // Query pull requests assigned to the API user.
+        {
+            let query = IssueSearchIssuesQuery {
+                assigned: Some(true),
+                state: Some(IssueSearchIssuesQueryState::Open),
+                r#type: Some(IssueSearchIssuesQueryType::Pulls),
+                labels: labels.clone(),
+                ..Default::default()
+            };
+
+            let (_, assigned_prs) = client.issue_search_issues(query).send().map_err(|err| {
+                error!("failed to query assigned pull requests: {err:?}");
+                ItemError::QueryError {
+                    service: "forgejo",
+                    message: format!("failed to query assigned pull requests: {err}"),
+                }
+            })?;
+
+            items.extend(
+                assigned_prs
+                    .into_iter()
+                    .map(|i| ForgejoItem::from_issue(i, true)),
+            );
+        }
+
+        // Query pull requests created by the API user.
+        {
+            let query = IssueSearchIssuesQuery {
+                created: Some(true),
+                state: Some(IssueSearchIssuesQueryState::Open),
+                r#type: Some(IssueSearchIssuesQueryType::Pulls),
+                labels: labels.clone(),
+                ..Default::default()
+            };
+
+            let (_, created_prs) = client.issue_search_issues(query).send().map_err(|err| {
+                error!("failed to query created pull requests: {err:?}");
+                ItemError::QueryError {
+                    service: "forgejo",
+                    message: format!("failed to query created pull requests: {err}"),
+                }
+            })?;
+
+            items.extend(
+                created_prs
+                    .into_iter()
+                    .map(|i| ForgejoItem::from_issue(i, true)),
+            );
+        }
+
+        Ok(items)
+    }
+
+    fn query_projects(
+        client: &Forgejo,
+        project_paths: &[String],
+        filters: &[Filter],
+    ) -> Result<Vec<ForgejoItem>, ItemError> {
+        use forgejo_api::structs::{
+            IssueListIssuesQuery, IssueListIssuesQueryState, IssueListIssuesQueryType,
+        };
+
+        let mut items = Vec::new();
+
+        // Build label filter string (comma-separated)
+        let labels: Option<String> = {
+            let label_list: Vec<&str> = filters
+                .iter()
+                .map(|f| {
+                    match f {
+                        Filter::Label(l) => l.as_str(),
+                    }
+                })
+                .collect();
+            if label_list.is_empty() {
+                None
+            } else {
+                Some(label_list.join(","))
+            }
+        };
+
+        for project_path in project_paths {
+            // Parse owner/repo from project path
+            let parts: Vec<&str> = project_path.splitn(2, '/').collect();
+            if parts.len() != 2 {
+                warn!("invalid project path (expected owner/repo): {project_path}");
+                continue;
+            }
+            let (owner, repo) = (parts[0], parts[1]);
+
+            // Query project issues
+            {
+                let query = IssueListIssuesQuery {
+                    state: Some(IssueListIssuesQueryState::Open),
+                    r#type: Some(IssueListIssuesQueryType::Issues),
+                    labels: labels.clone(),
+                    ..Default::default()
+                };
+
+                let (_, project_issues) = client
+                    .issue_list_issues(owner, repo, query)
+                    .send()
+                    .map_err(|err| {
+                        error!("failed to query project {project_path} issues: {err:?}");
+                        ItemError::QueryError {
+                            service: "forgejo",
+                            message: format!(
+                                "failed to query project {project_path} issues: {err}",
+                            ),
+                        }
+                    })?;
+
+                items.extend(
+                    project_issues
+                        .into_iter()
+                        .map(|i| ForgejoItem::from_issue(i, false)),
+                );
+            }
+
+            // Query project pull requests
+            {
+                let query = IssueListIssuesQuery {
+                    state: Some(IssueListIssuesQueryState::Open),
+                    r#type: Some(IssueListIssuesQueryType::Pulls),
+                    labels: labels.clone(),
+                    ..Default::default()
+                };
+
+                let (_, project_prs) = client
+                    .issue_list_issues(owner, repo, query)
+                    .send()
+                    .map_err(|err| {
+                        error!("failed to query project {project_path} pull requests: {err:?}");
+                        ItemError::QueryError {
+                            service: "forgejo",
+                            message: format!(
+                                "failed to query project {project_path} pull requests: {err}",
+                            ),
+                        }
+                    })?;
+
+                items.extend(
+                    project_prs
+                        .into_iter()
+                        .map(|i| ForgejoItem::from_issue(i, true)),
+                );
+            }
+        }
+
+        Ok(items)
+    }
+}
+
+impl ItemSource for ForgejoQuery {
+    fn fetch_items(
+        &self,
+        target: &QueryTarget,
+        filters: &[Filter],
+        existing_items: &mut ItemLookup,
+    ) -> Result<Vec<TodoItem>, ItemError> {
+        let client = self.client.as_ref().map_err(|err| {
+            error!("failed to connect to forgejo instance: {err:?}");
+            ItemError::ServiceError {
+                service: "forgejo",
+            }
+        })?;
+
+        let results = match target {
+            QueryTarget::SelfUser => Self::query_user(client, filters),
+            QueryTarget::Projects(projects) => Self::query_projects(client, projects, filters),
+        };
+
+        Ok(results?
+            .into_iter()
+            .filter_map(|result| {
+                if let Some(item) = existing_items.get_mut(&result.url) {
+                    // Update existing item
+                    if let Some(due) = result.due {
+                        item.set_due(due);
+                    }
+                    item.set_status(result.status);
+                    item.set_summary(result.summary);
+                    item.set_description(result.description);
+
+                    None
+                } else {
+                    // Create new item
+                    let mut item = TodoItem::builder();
+
+                    item.kind(result.kind)
+                        .status(result.status)
+                        .url(result.url.clone())
+                        .summary(result.summary)
+                        .description(result.description);
+
+                    if let Some(due) = result.due {
+                        item.due(due);
+                    }
+
+                    let item = item.build().expect("all item fields should be provided");
+
+                    Some(item)
+                }
+            })
+            .collect())
+    }
+}


### PR DESCRIPTION
Implement support for Forgejo.

Co-authored-by: GitHub Copilot (claude-opus-4.5)
Reviewed-by: Ben Boeckel <git@me.benboeckel.net>